### PR TITLE
Refresh featured project color palette

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -315,7 +315,8 @@
 
 .cot-badge {
   display: inline-block;
-  background: linear-gradient(135deg, rgba(76, 81, 191, 0.92), rgba(45, 212, 191, 0.7));
+  background: linear-gradient(160deg, rgba(8, 18, 36, 0.9), rgba(15, 32, 52, 0.88));
+
   color: var(--cot-cream);
   padding: 8px 24px;
   border-radius: 24px;
@@ -325,7 +326,10 @@
   text-transform: none !important;
   letter-spacing: 1.5px;
   box-shadow: 0 12px 30px rgba(30, 64, 122, 0.35), 0 12px 30px rgba(45, 212, 191, 0.2);
-  border: 1px solid rgba(45, 212, 191, 0.25);
+  border: 1px solid;
+    border-color: rgba(129, 140, 248, 0.38);
+    box-shadow: 0 20px 48px rgba(76, 81, 191, 0.22);
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.92), rgba(129, 140, 248, 0.9));
 }
 
 .cot-title {
@@ -366,7 +370,7 @@
 }
 
 .thought-bubble::before {
-  content: '';
+  /* content: ''; */
   position: absolute;
   bottom: -10px;
   left: 50%;
@@ -492,34 +496,30 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(37, 99, 235, 0.8));
+  background: linear-gradient(45deg, #4fc3f7, #29b6f6);
   position: relative;
   margin: 0 25px;
-  box-shadow: 0 0 20px rgba(37, 99, 235, 0.45);
+  box-shadow: 0 0 15px rgba(79, 195, 247, 0.6);
   animation: neuralPulse 3s infinite ease-in-out;
 }
 
 .neural-node.node-2 {
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.85), rgba(129, 140, 248, 0.75));
   animation-delay: 0.5s;
 }
 
 .neural-node.node-3 {
-  background: linear-gradient(135deg, rgba(45, 212, 191, 0.85), rgba(56, 189, 248, 0.78));
   animation-delay: 1s;
 }
 
 @keyframes neuralPulse {
-  0%, 100% { transform: scale(1); box-shadow: 0 0 22px rgba(79, 70, 229, 0.38); }
-  50% { transform: scale(1.2); box-shadow: 0 0 32px rgba(56, 189, 248, 0.5); }
+ 0%, 100% { transform: scale(1); box-shadow: 0 0 20px rgba(79, 195, 247, 0.6); }
+  50% { transform: scale(1.2); box-shadow: 0 0 30px rgba(79, 195, 247, 0.9); }
 }
 
 .neural-connection {
   position: absolute;
   height: 2px;
-  background: linear-gradient(90deg,
-    rgba(56, 189, 248, 0.65),
-    rgba(79, 70, 229, 0.55));
+  background: linear-gradient(90deg, #4fc3f7, #29b6f6);
   top: 50%;
   animation: dataFlow 2s infinite ease-in-out;
 }
@@ -578,7 +578,7 @@
 }
 
 .user-query-box {
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(79, 70, 229, 0.85));
+  /* background: #0b90ef; */
   color: var(--cot-cream);
   padding: 15px 20px;
   border-radius: 15px;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -205,6 +205,19 @@
   }
 }
 
+:root {
+  --cot-midnight: #040b1e;
+  --cot-navy: #081a32;
+  --cot-indigo: #4338ca;
+  --cot-plum: #7c3aed;
+  --cot-teal: #2dd4bf;
+  --cot-emerald: #34d399;
+  --cot-amber: #f59e0b;
+  --cot-rose: #fb7185;
+  --cot-cream: #f8fafc;
+  --cot-slate: #cbd5f5;
+}
+
 /* Chain-of-Thought Model Slide Styles */
 .cot-slide {
   position: relative;
@@ -244,9 +257,11 @@
   width: 100%;
   height: 100%;
   background: linear-gradient(135deg,
-    rgba(6, 11, 25, 0.95) 0%,
-    rgba(9, 24, 46, 0.92) 45%,
-    rgba(11, 144, 239, 0.75) 100%);
+    rgba(4, 11, 30, 0.95) 0%,
+    rgba(28, 16, 53, 0.9) 38%,
+    rgba(9, 39, 70, 0.85) 62%,
+    rgba(76, 29, 149, 0.78) 82%,
+    rgba(245, 158, 11, 0.45) 100%);
   z-index: 1;
 }
 
@@ -296,10 +311,11 @@
   margin-bottom: 30px;
 }
 
+
 .cot-badge {
   display: inline-block;
-  background: linear-gradient(135deg, #0b90ef, #38bdf8);
-  color: #f6fbff;
+  background: linear-gradient(135deg, var(--cot-plum), var(--cot-teal));
+  color: var(--cot-cream);
   padding: 8px 24px;
   border-radius: 24px;
   font-size: 14px;
@@ -307,21 +323,21 @@
   margin-bottom: 18px;
   text-transform: none !important;
   letter-spacing: 1.5px;
-  box-shadow: 0 12px 30px rgba(11, 144, 239, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 30px rgba(124, 58, 237, 0.35), 0 12px 30px rgba(45, 212, 191, 0.2);
+  border: 1px solid rgba(245, 158, 11, 0.35);
 }
 
 .cot-title {
   font-size: 48px;
   font-weight: 700;
-  color: #e7f1ff;
+  color: var(--cot-cream);
   margin-bottom: 18px;
-  text-shadow: 0 6px 30px rgba(0, 0, 0, 0.45);
+  text-shadow: 0 8px 32px rgba(4, 11, 30, 0.65);
 }
 
 .cot-subtitle {
   font-size: 18px;
-  color: rgba(226, 237, 255, 0.8);
+  color: rgba(203, 213, 225, 0.85);
   margin-bottom: 0;
   font-weight: 300;
 }
@@ -337,15 +353,15 @@
 }
 
 .thought-bubble {
-  background: rgba(7, 19, 38, 0.85);
+  background: rgba(8, 20, 40, 0.82);
   border-radius: 20px;
   padding: 20px;
   min-width: 180px;
   position: relative;
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 18px 45px rgba(4, 11, 30, 0.55);
   transition: all 0.3s ease;
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(11, 144, 239, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.28);
 }
 
 .thought-bubble::before {
@@ -358,12 +374,42 @@
   height: 0;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
-  border-top: 10px solid rgba(7, 19, 38, 0.85);
+  border-top: 10px solid rgba(8, 20, 40, 0.82);
 }
 
 .thought-bubble:hover {
   transform: translateY(-5px) scale(1.05);
-  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 22px 55px rgba(4, 11, 30, 0.65);
+}
+
+.gpt-agent {
+  background: linear-gradient(160deg, rgba(6, 28, 42, 0.92), rgba(45, 212, 191, 0.16));
+  border-color: rgba(45, 212, 191, 0.45);
+  box-shadow: 0 20px 48px rgba(13, 148, 136, 0.2);
+}
+
+.gpt-agent::before {
+  border-top-color: rgba(6, 28, 42, 0.92);
+}
+
+.manager-agent {
+  background: linear-gradient(160deg, rgba(27, 16, 44, 0.92), rgba(124, 58, 237, 0.2));
+  border-color: rgba(124, 58, 237, 0.45);
+  box-shadow: 0 20px 48px rgba(124, 58, 237, 0.22);
+}
+
+.manager-agent::before {
+  border-top-color: rgba(27, 16, 44, 0.92);
+}
+
+.final-output {
+  background: linear-gradient(160deg, rgba(36, 20, 9, 0.9), rgba(245, 158, 11, 0.22));
+  border-color: rgba(245, 158, 11, 0.45);
+  box-shadow: 0 22px 52px rgba(245, 158, 11, 0.18);
+}
+
+.final-output::before {
+  border-top-color: rgba(36, 20, 9, 0.9);
 }
 
 .bubble-content {
@@ -380,23 +426,24 @@
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 1px;
+  box-shadow: 0 10px 25px rgba(4, 11, 30, 0.35);
 }
 
 .gpt-badge {
-  background: linear-gradient(135deg, #0b90ef, #38bdf8);
+  background: linear-gradient(135deg, var(--cot-teal), var(--cot-emerald));
 }
 
 .manager-badge {
-  background: linear-gradient(135deg, #0b5ed7, #0b90ef);
+  background: linear-gradient(135deg, var(--cot-plum), rgba(216, 180, 254, 0.9));
 }
 
 .final-badge {
-  background: linear-gradient(135deg, #38bdf8, #7dd3fc);
-  color: #06243f;
+  background: linear-gradient(135deg, var(--cot-amber), #f97316);
+  color: #2e1500;
 }
 
 .bubble-content p {
-  color: rgba(226, 237, 255, 0.85);
+  color: rgba(236, 241, 255, 0.88);
   font-weight: 600;
   margin-bottom: 10px;
   font-size: 16px;
@@ -410,7 +457,7 @@
 }
 
 .code-snippet code {
-  color: #7dd3fc;
+  color: var(--cot-teal);
   font-family: 'Courier New', monospace;
   font-size: 12px;
   font-weight: 500;
@@ -418,9 +465,9 @@
 
 .thought-arrow {
   font-size: 24px;
-  color: rgba(173, 206, 255, 0.85);
+  color: rgba(253, 186, 116, 0.85);
   font-weight: bold;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  text-shadow: 0 2px 12px rgba(245, 158, 11, 0.45);
   animation: pulse 2s infinite;
 }
 
@@ -439,34 +486,40 @@
   align-items: center;
 }
 
+
 .neural-node {
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #0b90ef, #38bdf8);
+  background: linear-gradient(135deg, var(--cot-teal), var(--cot-indigo));
   position: relative;
   margin: 0 25px;
-  box-shadow: 0 0 20px rgba(11, 144, 239, 0.55);
+  box-shadow: 0 0 20px rgba(45, 212, 191, 0.5);
   animation: neuralPulse 3s infinite ease-in-out;
 }
 
 .neural-node.node-2 {
+  background: linear-gradient(135deg, var(--cot-plum), var(--cot-rose));
   animation-delay: 0.5s;
 }
 
 .neural-node.node-3 {
+  background: linear-gradient(135deg, var(--cot-amber), var(--cot-teal));
   animation-delay: 1s;
 }
 
 @keyframes neuralPulse {
-  0%, 100% { transform: scale(1); box-shadow: 0 0 22px rgba(11, 144, 239, 0.55); }
-  50% { transform: scale(1.2); box-shadow: 0 0 32px rgba(56, 189, 248, 0.85); }
+  0%, 100% { transform: scale(1); box-shadow: 0 0 22px rgba(76, 29, 149, 0.4); }
+  50% { transform: scale(1.2); box-shadow: 0 0 32px rgba(45, 212, 191, 0.55); }
 }
 
 .neural-connection {
   position: absolute;
   height: 2px;
-  background: linear-gradient(90deg, rgba(11, 144, 239, 0.85), rgba(56, 189, 248, 0.6));
+  background: linear-gradient(90deg,
+    rgba(45, 212, 191, 0.85),
+    rgba(124, 58, 237, 0.75),
+    rgba(245, 158, 11, 0.6));
   top: 50%;
   animation: dataFlow 2s infinite ease-in-out;
 }
@@ -494,20 +547,24 @@
 }
 
 .example-header h3 {
-  color: #0b90ef;
+  color: var(--cot-cream);
   font-size: 24px;
   margin-bottom: 10px;
   font-weight: 600;
+  background: linear-gradient(120deg, var(--cot-teal), var(--cot-plum), var(--cot-amber));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .example-header p {
-  color: rgba(226, 237, 255, 0.7);
+  color: rgba(203, 213, 225, 0.78);
   font-size: 16px;
   margin-bottom: 30px;
 }
 
 .conversation-example {
-  background: rgba(7, 18, 35, 0.85);
+  background: linear-gradient(160deg, rgba(8, 18, 36, 0.88), rgba(28, 14, 36, 0.88));
   border-radius: 20px;
   padding: 25px;
   margin-bottom: 30px;
@@ -515,17 +572,19 @@
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid rgba(11, 144, 239, 0.25);
-  box-shadow: 0 18px 40px rgba(2, 8, 20, 0.55);
+  border: 1px solid rgba(124, 58, 237, 0.28);
+  box-shadow: 0 18px 45px rgba(4, 11, 30, 0.55);
 }
 
 .user-query-box {
-  background: linear-gradient(135deg, rgba(11, 144, 239, 0.95), rgba(56, 189, 248, 0.95));
-  color: #f6fbff;
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.95), rgba(124, 58, 237, 0.9));
+  color: var(--cot-cream);
   padding: 15px 20px;
   border-radius: 15px;
   margin-bottom: 20px;
   font-size: 16px;
+  border: 1px solid rgba(45, 212, 191, 0.4);
+  box-shadow: 0 12px 32px rgba(45, 212, 191, 0.25);
 }
 
 .agent-conversation {
@@ -534,76 +593,93 @@
   gap: 15px;
 }
 
+
 .agent-response {
   padding: 15px 20px;
   border-radius: 15px;
   border-left: 4px solid;
   font-size: 14px;
   line-height: 1.5;
-  background: rgba(11, 28, 52, 0.6);
+  background: rgba(6, 14, 28, 0.72);
+  box-shadow: 0 12px 32px rgba(4, 11, 30, 0.45);
 }
 
 .gpt-response {
-  background: rgba(11, 144, 239, 0.08);
-  border-left-color: rgba(56, 189, 248, 0.8);
+  background: linear-gradient(160deg, rgba(6, 24, 38, 0.9), rgba(45, 212, 191, 0.16));
+  border-left-color: rgba(45, 212, 191, 0.8);
 }
 
 .manager-response {
-  background: rgba(14, 165, 233, 0.07);
-  border-left-color: rgba(14, 165, 233, 0.85);
+  background: linear-gradient(160deg, rgba(24, 12, 42, 0.9), rgba(124, 58, 237, 0.18));
+  border-left-color: rgba(124, 58, 237, 0.75);
 }
 
 .refined-response {
-  background: rgba(125, 211, 252, 0.08);
-  border-left-color: rgba(125, 211, 252, 0.85);
+  background: linear-gradient(160deg, rgba(34, 18, 9, 0.9), rgba(245, 158, 11, 0.2));
+  border-left-color: rgba(245, 158, 11, 0.78);
 }
 
 .agent-label {
   font-weight: bold;
   margin-bottom: 8px;
-  color: #dbeafe;
+  color: var(--cot-slate);
   font-size: 14px;
 }
 
+.gpt-response .agent-label {
+  color: var(--cot-teal);
+}
+
+.manager-response .agent-label {
+  color: var(--cot-plum);
+}
+
+.refined-response .agent-label {
+  color: var(--cot-amber);
+}
+
+
 .completion-message {
-  background: linear-gradient(135deg, rgba(6, 15, 30, 0.95) 0%, rgba(11, 144, 239, 0.85) 100%);
+  background: linear-gradient(135deg, rgba(6, 15, 30, 0.95) 0%, rgba(76, 29, 149, 0.88) 55%, rgba(245, 158, 11, 0.7) 100%);
   border-radius: 15px;
   padding: 25px;
   margin: 30px 0;
   text-align: center;
   color: white;
-  box-shadow: 0 18px 45px rgba(2, 10, 24, 0.5);
-  border: 1px solid rgba(56, 189, 248, 0.2);
+  box-shadow: 0 18px 48px rgba(4, 11, 30, 0.55);
+  border: 1px solid rgba(124, 58, 237, 0.3);
 }
 
 .completion-message h4 {
   margin: 0 0 15px 0;
   font-size: 22px;
   font-weight: 600;
-  color: #7dd3fc;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+  color: var(--cot-amber);
+  text-shadow: 0 2px 12px rgba(245, 158, 11, 0.45);
 }
 
 .completion-message p {
   margin: 0;
   font-size: 16px;
   line-height: 1.6;
-  color: rgba(226, 237, 255, 0.85);
+  color: rgba(236, 241, 255, 0.85);
 }
+
 
 .agent-response p {
   margin: 0;
-  color: rgba(224, 234, 255, 0.85);
+  color: rgba(236, 241, 255, 0.88);
   font-style: italic;
 }
 
 .iteration-arrow {
   text-align: center;
   font-size: 20px;
-  color: rgba(173, 206, 255, 0.85);
+  color: rgba(124, 58, 237, 0.8);
   font-weight: bold;
   margin: 10px 0;
   animation: bounce 2s infinite;
+  text-shadow: 0 0 12px rgba(124, 58, 237, 0.45);
 }
 
 @keyframes bounce {
@@ -615,7 +691,7 @@
 /* Interactive Demo Button */
 .cot-demo-btn {
   position: relative;
-  background: linear-gradient(135deg, #0b90ef, #38bdf8, #0ea5e9, #38bdf8);
+  background: linear-gradient(135deg, var(--cot-teal), var(--cot-plum), var(--cot-amber));
   background-size: 250% 250%;
   border: none;
   border-radius: 50px;
@@ -626,7 +702,7 @@
   cursor: pointer;
   transition: all 0.3s ease;
   overflow: hidden;
-  box-shadow: 0 12px 35px rgba(11, 144, 239, 0.35);
+  box-shadow: 0 12px 35px rgba(124, 58, 237, 0.35), 0 12px 35px rgba(245, 158, 11, 0.22);
   animation: gradientShift 4s ease infinite;
   min-width: 320px;
   padding-left: 60px;
@@ -640,11 +716,12 @@
 
 .cot-demo-btn:hover {
   transform: translateY(-3px);
-  box-shadow: 0 18px 45px rgba(11, 144, 239, 0.45);
+  box-shadow: 0 20px 50px rgba(124, 58, 237, 0.35), 0 20px 50px rgba(45, 212, 191, 0.25);
 }
 
 .cot-demo-btn:active {
   transform: translateY(-1px);
+  box-shadow: 0 10px 28px rgba(4, 11, 30, 0.45);
 }
 
 .btn-glow {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -207,15 +207,17 @@
 
 :root {
   --cot-midnight: #040b1e;
-  --cot-navy: #081a32;
-  --cot-indigo: #4338ca;
-  --cot-plum: #7c3aed;
+  --cot-navy: #0b1f3d;
+  --cot-royal: #1e3a8a;
+  --cot-indigo: #3730a3;
+  --cot-plum: #4c1d95;
   --cot-teal: #2dd4bf;
-  --cot-emerald: #34d399;
-  --cot-amber: #f59e0b;
-  --cot-rose: #fb7185;
+  --cot-emerald: #38bdf8;
+  --cot-amber: #fbbf24;
+  --cot-rose: #818cf8;
   --cot-cream: #f8fafc;
-  --cot-slate: #cbd5f5;
+  --cot-slate: rgba(203, 213, 225, 0.85);
+  --cot-ice: rgba(148, 163, 184, 0.28);
 }
 
 /* Chain-of-Thought Model Slide Styles */
@@ -256,12 +258,11 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(135deg,
-    rgba(4, 11, 30, 0.95) 0%,
-    rgba(28, 16, 53, 0.9) 38%,
-    rgba(9, 39, 70, 0.85) 62%,
-    rgba(76, 29, 149, 0.78) 82%,
-    rgba(245, 158, 11, 0.45) 100%);
+  background: linear-gradient(140deg,
+    rgba(4, 11, 30, 0.96) 0%,
+    rgba(11, 31, 61, 0.92) 48%,
+    rgba(30, 58, 138, 0.86) 78%,
+    rgba(45, 212, 191, 0.22) 100%);
   z-index: 1;
 }
 
@@ -314,7 +315,7 @@
 
 .cot-badge {
   display: inline-block;
-  background: linear-gradient(135deg, var(--cot-plum), var(--cot-teal));
+  background: linear-gradient(135deg, rgba(76, 81, 191, 0.92), rgba(45, 212, 191, 0.7));
   color: var(--cot-cream);
   padding: 8px 24px;
   border-radius: 24px;
@@ -323,8 +324,8 @@
   margin-bottom: 18px;
   text-transform: none !important;
   letter-spacing: 1.5px;
-  box-shadow: 0 12px 30px rgba(124, 58, 237, 0.35), 0 12px 30px rgba(45, 212, 191, 0.2);
-  border: 1px solid rgba(245, 158, 11, 0.35);
+  box-shadow: 0 12px 30px rgba(30, 64, 122, 0.35), 0 12px 30px rgba(45, 212, 191, 0.2);
+  border: 1px solid rgba(45, 212, 191, 0.25);
 }
 
 .cot-title {
@@ -332,12 +333,12 @@
   font-weight: 700;
   color: var(--cot-cream);
   margin-bottom: 18px;
-  text-shadow: 0 8px 32px rgba(4, 11, 30, 0.65);
+  text-shadow: 0 10px 35px rgba(4, 11, 30, 0.6), 0 0 22px rgba(45, 212, 191, 0.18);
 }
 
 .cot-subtitle {
   font-size: 18px;
-  color: rgba(203, 213, 225, 0.85);
+  color: rgba(226, 232, 240, 0.82);
   margin-bottom: 0;
   font-weight: 300;
 }
@@ -361,7 +362,7 @@
   box-shadow: 0 18px 45px rgba(4, 11, 30, 0.55);
   transition: all 0.3s ease;
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  border: 1px solid var(--cot-ice);
 }
 
 .thought-bubble::before {
@@ -383,33 +384,33 @@
 }
 
 .gpt-agent {
-  background: linear-gradient(160deg, rgba(6, 28, 42, 0.92), rgba(45, 212, 191, 0.16));
-  border-color: rgba(45, 212, 191, 0.45);
-  box-shadow: 0 20px 48px rgba(13, 148, 136, 0.2);
+  background: linear-gradient(155deg, rgba(8, 26, 46, 0.92), rgba(56, 189, 248, 0.18));
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: 0 20px 48px rgba(37, 99, 235, 0.22);
 }
 
 .gpt-agent::before {
-  border-top-color: rgba(6, 28, 42, 0.92);
+  border-top-color: rgba(8, 26, 46, 0.92);
 }
 
 .manager-agent {
-  background: linear-gradient(160deg, rgba(27, 16, 44, 0.92), rgba(124, 58, 237, 0.2));
-  border-color: rgba(124, 58, 237, 0.45);
-  box-shadow: 0 20px 48px rgba(124, 58, 237, 0.22);
+  background: linear-gradient(155deg, rgba(11, 24, 52, 0.92), rgba(99, 102, 241, 0.18));
+  border-color: rgba(129, 140, 248, 0.38);
+  box-shadow: 0 20px 48px rgba(76, 81, 191, 0.22);
 }
 
 .manager-agent::before {
-  border-top-color: rgba(27, 16, 44, 0.92);
+  border-top-color: rgba(11, 24, 52, 0.92);
 }
 
 .final-output {
-  background: linear-gradient(160deg, rgba(36, 20, 9, 0.9), rgba(245, 158, 11, 0.22));
-  border-color: rgba(245, 158, 11, 0.45);
-  box-shadow: 0 22px 52px rgba(245, 158, 11, 0.18);
+  background: linear-gradient(155deg, rgba(15, 32, 52, 0.9), rgba(251, 191, 36, 0.16));
+  border-color: rgba(251, 191, 36, 0.32);
+  box-shadow: 0 22px 52px rgba(15, 32, 52, 0.35);
 }
 
 .final-output::before {
-  border-top-color: rgba(36, 20, 9, 0.9);
+  border-top-color: rgba(15, 32, 52, 0.9);
 }
 
 .bubble-content {
@@ -426,20 +427,20 @@
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 1px;
-  box-shadow: 0 10px 25px rgba(4, 11, 30, 0.35);
+  box-shadow: 0 12px 28px rgba(4, 11, 30, 0.32);
 }
 
 .gpt-badge {
-  background: linear-gradient(135deg, var(--cot-teal), var(--cot-emerald));
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(37, 99, 235, 0.92));
 }
 
 .manager-badge {
-  background: linear-gradient(135deg, var(--cot-plum), rgba(216, 180, 254, 0.9));
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.92), rgba(129, 140, 248, 0.9));
 }
 
 .final-badge {
-  background: linear-gradient(135deg, var(--cot-amber), #f97316);
-  color: #2e1500;
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.9), rgba(249, 115, 22, 0.78));
+  color: #241708;
 }
 
 .bubble-content p {
@@ -465,9 +466,9 @@
 
 .thought-arrow {
   font-size: 24px;
-  color: rgba(253, 186, 116, 0.85);
+  color: rgba(125, 211, 252, 0.85);
   font-weight: bold;
-  text-shadow: 0 2px 12px rgba(245, 158, 11, 0.45);
+  text-shadow: 0 2px 12px rgba(59, 130, 246, 0.35);
   animation: pulse 2s infinite;
 }
 
@@ -491,35 +492,34 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--cot-teal), var(--cot-indigo));
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(37, 99, 235, 0.8));
   position: relative;
   margin: 0 25px;
-  box-shadow: 0 0 20px rgba(45, 212, 191, 0.5);
+  box-shadow: 0 0 20px rgba(37, 99, 235, 0.45);
   animation: neuralPulse 3s infinite ease-in-out;
 }
 
 .neural-node.node-2 {
-  background: linear-gradient(135deg, var(--cot-plum), var(--cot-rose));
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.85), rgba(129, 140, 248, 0.75));
   animation-delay: 0.5s;
 }
 
 .neural-node.node-3 {
-  background: linear-gradient(135deg, var(--cot-amber), var(--cot-teal));
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.85), rgba(56, 189, 248, 0.78));
   animation-delay: 1s;
 }
 
 @keyframes neuralPulse {
-  0%, 100% { transform: scale(1); box-shadow: 0 0 22px rgba(76, 29, 149, 0.4); }
-  50% { transform: scale(1.2); box-shadow: 0 0 32px rgba(45, 212, 191, 0.55); }
+  0%, 100% { transform: scale(1); box-shadow: 0 0 22px rgba(79, 70, 229, 0.38); }
+  50% { transform: scale(1.2); box-shadow: 0 0 32px rgba(56, 189, 248, 0.5); }
 }
 
 .neural-connection {
   position: absolute;
   height: 2px;
   background: linear-gradient(90deg,
-    rgba(45, 212, 191, 0.85),
-    rgba(124, 58, 237, 0.75),
-    rgba(245, 158, 11, 0.6));
+    rgba(56, 189, 248, 0.65),
+    rgba(79, 70, 229, 0.55));
   top: 50%;
   animation: dataFlow 2s infinite ease-in-out;
 }
@@ -551,7 +551,7 @@
   font-size: 24px;
   margin-bottom: 10px;
   font-weight: 600;
-  background: linear-gradient(120deg, var(--cot-teal), var(--cot-plum), var(--cot-amber));
+  background: linear-gradient(120deg, rgba(94, 234, 212, 0.85), rgba(125, 211, 252, 0.9));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -563,8 +563,9 @@
   margin-bottom: 30px;
 }
 
+
 .conversation-example {
-  background: linear-gradient(160deg, rgba(8, 18, 36, 0.88), rgba(28, 14, 36, 0.88));
+  background: linear-gradient(160deg, rgba(8, 18, 36, 0.9), rgba(15, 32, 52, 0.88));
   border-radius: 20px;
   padding: 25px;
   margin-bottom: 30px;
@@ -572,19 +573,19 @@
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid rgba(124, 58, 237, 0.28);
-  box-shadow: 0 18px 45px rgba(4, 11, 30, 0.55);
+  border: 1px solid rgba(79, 70, 229, 0.25);
+  box-shadow: 0 18px 45px rgba(4, 11, 30, 0.5);
 }
 
 .user-query-box {
-  background: linear-gradient(135deg, rgba(45, 212, 191, 0.95), rgba(124, 58, 237, 0.9));
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(79, 70, 229, 0.85));
   color: var(--cot-cream);
   padding: 15px 20px;
   border-radius: 15px;
   margin-bottom: 20px;
   font-size: 16px;
-  border: 1px solid rgba(45, 212, 191, 0.4);
-  box-shadow: 0 12px 32px rgba(45, 212, 191, 0.25);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  box-shadow: 0 12px 32px rgba(30, 64, 122, 0.32);
 }
 
 .agent-conversation {
@@ -594,29 +595,30 @@
 }
 
 
+
 .agent-response {
   padding: 15px 20px;
   border-radius: 15px;
   border-left: 4px solid;
   font-size: 14px;
   line-height: 1.5;
-  background: rgba(6, 14, 28, 0.72);
-  box-shadow: 0 12px 32px rgba(4, 11, 30, 0.45);
+  background: rgba(6, 14, 28, 0.75);
+  box-shadow: 0 12px 32px rgba(4, 11, 30, 0.42);
 }
 
 .gpt-response {
-  background: linear-gradient(160deg, rgba(6, 24, 38, 0.9), rgba(45, 212, 191, 0.16));
-  border-left-color: rgba(45, 212, 191, 0.8);
+  background: linear-gradient(160deg, rgba(8, 28, 46, 0.9), rgba(56, 189, 248, 0.14));
+  border-left-color: rgba(56, 189, 248, 0.65);
 }
 
 .manager-response {
-  background: linear-gradient(160deg, rgba(24, 12, 42, 0.9), rgba(124, 58, 237, 0.18));
-  border-left-color: rgba(124, 58, 237, 0.75);
+  background: linear-gradient(160deg, rgba(12, 24, 52, 0.9), rgba(99, 102, 241, 0.16));
+  border-left-color: rgba(129, 140, 248, 0.6);
 }
 
 .refined-response {
-  background: linear-gradient(160deg, rgba(34, 18, 9, 0.9), rgba(245, 158, 11, 0.2));
-  border-left-color: rgba(245, 158, 11, 0.78);
+  background: linear-gradient(160deg, rgba(15, 29, 52, 0.9), rgba(251, 191, 36, 0.16));
+  border-left-color: rgba(251, 191, 36, 0.5);
 }
 
 .agent-label {
@@ -627,42 +629,43 @@
 }
 
 .gpt-response .agent-label {
-  color: var(--cot-teal);
+  color: rgba(125, 211, 252, 0.9);
 }
 
 .manager-response .agent-label {
-  color: var(--cot-plum);
+  color: rgba(165, 180, 252, 0.85);
 }
 
 .refined-response .agent-label {
-  color: var(--cot-amber);
+  color: rgba(251, 191, 36, 0.72);
 }
 
 
+
 .completion-message {
-  background: linear-gradient(135deg, rgba(6, 15, 30, 0.95) 0%, rgba(76, 29, 149, 0.88) 55%, rgba(245, 158, 11, 0.7) 100%);
+  background: linear-gradient(135deg, rgba(6, 15, 30, 0.95) 0%, rgba(49, 74, 134, 0.88) 55%, rgba(251, 191, 36, 0.55) 100%);
   border-radius: 15px;
   padding: 25px;
   margin: 30px 0;
   text-align: center;
   color: white;
-  box-shadow: 0 18px 48px rgba(4, 11, 30, 0.55);
-  border: 1px solid rgba(124, 58, 237, 0.3);
+  box-shadow: 0 18px 48px rgba(4, 11, 30, 0.5);
+  border: 1px solid rgba(129, 140, 248, 0.25);
 }
 
 .completion-message h4 {
   margin: 0 0 15px 0;
   font-size: 22px;
   font-weight: 600;
-  color: var(--cot-amber);
-  text-shadow: 0 2px 12px rgba(245, 158, 11, 0.45);
+  color: rgba(251, 191, 36, 0.85);
+  text-shadow: 0 2px 12px rgba(251, 191, 36, 0.35);
 }
 
 .completion-message p {
   margin: 0;
   font-size: 16px;
   line-height: 1.6;
-  color: rgba(236, 241, 255, 0.85);
+  color: rgba(226, 232, 240, 0.88);
 }
 
 
@@ -675,11 +678,11 @@
 .iteration-arrow {
   text-align: center;
   font-size: 20px;
-  color: rgba(124, 58, 237, 0.8);
+  color: rgba(148, 163, 255, 0.8);
   font-weight: bold;
   margin: 10px 0;
   animation: bounce 2s infinite;
-  text-shadow: 0 0 12px rgba(124, 58, 237, 0.45);
+  text-shadow: 0 0 12px rgba(79, 70, 229, 0.4);
 }
 
 @keyframes bounce {
@@ -691,8 +694,8 @@
 /* Interactive Demo Button */
 .cot-demo-btn {
   position: relative;
-  background: linear-gradient(135deg, var(--cot-teal), var(--cot-plum), var(--cot-amber));
-  background-size: 250% 250%;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.95), rgba(79, 70, 229, 0.95));
+  background-size: 180% 180%;
   border: none;
   border-radius: 50px;
   padding: 15px 40px;
@@ -702,8 +705,8 @@
   cursor: pointer;
   transition: all 0.3s ease;
   overflow: hidden;
-  box-shadow: 0 12px 35px rgba(124, 58, 237, 0.35), 0 12px 35px rgba(245, 158, 11, 0.22);
-  animation: gradientShift 4s ease infinite;
+  box-shadow: 0 12px 35px rgba(30, 64, 122, 0.35), 0 12px 35px rgba(56, 189, 248, 0.25);
+  animation: gradientShift 6s ease infinite;
   min-width: 320px;
   padding-left: 60px;
   padding-right: 60px;
@@ -716,7 +719,7 @@
 
 .cot-demo-btn:hover {
   transform: translateY(-3px);
-  box-shadow: 0 20px 50px rgba(124, 58, 237, 0.35), 0 20px 50px rgba(45, 212, 191, 0.25);
+  box-shadow: 0 20px 50px rgba(30, 64, 122, 0.35), 0 20px 50px rgba(56, 189, 248, 0.25);
 }
 
 .cot-demo-btn:active {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -243,12 +243,10 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(135deg, 
-    rgba(0, 0, 0, 0.95) 0%, 
-    rgba(13, 71, 161, 0.98) 25%, 
-    rgba(26, 35, 126, 0.95) 50%, 
-    rgba(74, 20, 140, 0.98) 75%, 
-    rgba(0, 0, 0, 0.95) 100%);
+  background: linear-gradient(135deg,
+    rgba(6, 11, 25, 0.95) 0%,
+    rgba(9, 24, 46, 0.92) 45%,
+    rgba(11, 144, 239, 0.75) 100%);
   z-index: 1;
 }
 
@@ -300,33 +298,30 @@
 
 .cot-badge {
   display: inline-block;
-  background: linear-gradient(45deg, #ff6b6b, #ffa500);
-  color: white;
-  padding: 8px 20px;
-  border-radius: 20px;
+  background: linear-gradient(135deg, #0b90ef, #38bdf8);
+  color: #f6fbff;
+  padding: 8px 24px;
+  border-radius: 24px;
   font-size: 14px;
   font-weight: 600;
-  margin-bottom: 15px;
+  margin-bottom: 18px;
   text-transform: none !important;
-  letter-spacing: 1px;
-  box-shadow: 0 4px 15px rgba(255, 107, 107, 0.3);
+  letter-spacing: 1.5px;
+  box-shadow: 0 12px 30px rgba(11, 144, 239, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .cot-title {
   font-size: 48px;
   font-weight: 700;
-  color: #ffffff;
-  margin-bottom: 15px;
-  text-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
-  background: linear-gradient(45deg, #ffffff, #e3f2fd);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #e7f1ff;
+  margin-bottom: 18px;
+  text-shadow: 0 6px 30px rgba(0, 0, 0, 0.45);
 }
 
 .cot-subtitle {
   font-size: 18px;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(226, 237, 255, 0.8);
   margin-bottom: 0;
   font-weight: 300;
 }
@@ -342,15 +337,15 @@
 }
 
 .thought-bubble {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(7, 19, 38, 0.85);
   border-radius: 20px;
   padding: 20px;
   min-width: 180px;
   position: relative;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.45);
   transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(11, 144, 239, 0.25);
 }
 
 .thought-bubble::before {
@@ -363,12 +358,12 @@
   height: 0;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
-  border-top: 10px solid rgba(255, 255, 255, 0.95);
+  border-top: 10px solid rgba(7, 19, 38, 0.85);
 }
 
 .thought-bubble:hover {
   transform: translateY(-5px) scale(1.05);
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.5);
 }
 
 .bubble-content {
@@ -384,23 +379,24 @@
   margin-bottom: 10px;
   font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 1px;
 }
 
 .gpt-badge {
-  background: linear-gradient(45deg, #4fc3f7, #29b6f6);
+  background: linear-gradient(135deg, #0b90ef, #38bdf8);
 }
 
 .manager-badge {
-  background: linear-gradient(45deg, #ff9800, #f57c00);
+  background: linear-gradient(135deg, #0b5ed7, #0b90ef);
 }
 
 .final-badge {
-  background: linear-gradient(45deg, #4caf50, #388e3c);
+  background: linear-gradient(135deg, #38bdf8, #7dd3fc);
+  color: #06243f;
 }
 
 .bubble-content p {
-  color: #333;
+  color: rgba(226, 237, 255, 0.85);
   font-weight: 600;
   margin-bottom: 10px;
   font-size: 16px;
@@ -414,7 +410,7 @@
 }
 
 .code-snippet code {
-  color: #4fc3f7;
+  color: #7dd3fc;
   font-family: 'Courier New', monospace;
   font-size: 12px;
   font-weight: 500;
@@ -422,7 +418,7 @@
 
 .thought-arrow {
   font-size: 24px;
-  color: #ffffff;
+  color: rgba(173, 206, 255, 0.85);
   font-weight: bold;
   text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   animation: pulse 2s infinite;
@@ -447,10 +443,10 @@
   width: 30px;
   height: 30px;
   border-radius: 50%;
-  background: linear-gradient(45deg, #4fc3f7, #29b6f6);
+  background: linear-gradient(135deg, #0b90ef, #38bdf8);
   position: relative;
   margin: 0 25px;
-  box-shadow: 0 0 15px rgba(79, 195, 247, 0.6);
+  box-shadow: 0 0 20px rgba(11, 144, 239, 0.55);
   animation: neuralPulse 3s infinite ease-in-out;
 }
 
@@ -463,14 +459,14 @@
 }
 
 @keyframes neuralPulse {
-  0%, 100% { transform: scale(1); box-shadow: 0 0 20px rgba(79, 195, 247, 0.6); }
-  50% { transform: scale(1.2); box-shadow: 0 0 30px rgba(79, 195, 247, 0.9); }
+  0%, 100% { transform: scale(1); box-shadow: 0 0 22px rgba(11, 144, 239, 0.55); }
+  50% { transform: scale(1.2); box-shadow: 0 0 32px rgba(56, 189, 248, 0.85); }
 }
 
 .neural-connection {
   position: absolute;
   height: 2px;
-  background: linear-gradient(90deg, #4fc3f7, #29b6f6);
+  background: linear-gradient(90deg, rgba(11, 144, 239, 0.85), rgba(56, 189, 248, 0.6));
   top: 50%;
   animation: dataFlow 2s infinite ease-in-out;
 }
@@ -498,20 +494,20 @@
 }
 
 .example-header h3 {
-  color: #4fc3f7;
+  color: #0b90ef;
   font-size: 24px;
   margin-bottom: 10px;
   font-weight: 600;
 }
 
 .example-header p {
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(226, 237, 255, 0.7);
   font-size: 16px;
   margin-bottom: 30px;
 }
 
 .conversation-example {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(7, 18, 35, 0.85);
   border-radius: 20px;
   padding: 25px;
   margin-bottom: 30px;
@@ -519,12 +515,13 @@
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(11, 144, 239, 0.25);
+  box-shadow: 0 18px 40px rgba(2, 8, 20, 0.55);
 }
 
 .user-query-box {
-  background: linear-gradient(45deg, #5c6bc0, #3f51b5);
-  color: white;
+  background: linear-gradient(135deg, rgba(11, 144, 239, 0.95), rgba(56, 189, 248, 0.95));
+  color: #f6fbff;
   padding: 15px 20px;
   border-radius: 15px;
   margin-bottom: 20px;
@@ -543,66 +540,67 @@
   border-left: 4px solid;
   font-size: 14px;
   line-height: 1.5;
+  background: rgba(11, 28, 52, 0.6);
 }
 
 .gpt-response {
-  background: rgba(79, 195, 247, 0.1);
-  border-left-color: #4fc3f7;
+  background: rgba(11, 144, 239, 0.08);
+  border-left-color: rgba(56, 189, 248, 0.8);
 }
 
 .manager-response {
-  background: rgba(255, 152, 0, 0.1);
-  border-left-color: #ff9800;
+  background: rgba(14, 165, 233, 0.07);
+  border-left-color: rgba(14, 165, 233, 0.85);
 }
 
 .refined-response {
-  background: rgba(76, 175, 80, 0.1);
-  border-left-color: #4caf50;
+  background: rgba(125, 211, 252, 0.08);
+  border-left-color: rgba(125, 211, 252, 0.85);
 }
 
 .agent-label {
   font-weight: bold;
   margin-bottom: 8px;
-  color: #ffffff;
+  color: #dbeafe;
   font-size: 14px;
 }
 
 .completion-message {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, rgba(6, 15, 30, 0.95) 0%, rgba(11, 144, 239, 0.85) 100%);
   border-radius: 15px;
   padding: 25px;
   margin: 30px 0;
   text-align: center;
   color: white;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 18px 45px rgba(2, 10, 24, 0.5);
+  border: 1px solid rgba(56, 189, 248, 0.2);
 }
 
 .completion-message h4 {
   margin: 0 0 15px 0;
   font-size: 22px;
   font-weight: 600;
-  color: #4fc3f7;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  color: #7dd3fc;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
 }
 
 .completion-message p {
   margin: 0;
   font-size: 16px;
   line-height: 1.6;
-  opacity: 0.9;
+  color: rgba(226, 237, 255, 0.85);
 }
 
 .agent-response p {
   margin: 0;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(224, 234, 255, 0.85);
   font-style: italic;
 }
 
 .iteration-arrow {
   text-align: center;
   font-size: 20px;
-  color: #4fc3f7;
+  color: rgba(173, 206, 255, 0.85);
   font-weight: bold;
   margin: 10px 0;
   animation: bounce 2s infinite;
@@ -617,8 +615,8 @@
 /* Interactive Demo Button */
 .cot-demo-btn {
   position: relative;
-  background: linear-gradient(45deg, #667eea, #764ba2, #6B73FF, #9A9CE2);
-  background-size: 300% 300%;
+  background: linear-gradient(135deg, #0b90ef, #38bdf8, #0ea5e9, #38bdf8);
+  background-size: 250% 250%;
   border: none;
   border-radius: 50px;
   padding: 15px 40px;
@@ -628,7 +626,7 @@
   cursor: pointer;
   transition: all 0.3s ease;
   overflow: hidden;
-  box-shadow: 0 10px 30px rgba(102, 126, 234, 0.4);
+  box-shadow: 0 12px 35px rgba(11, 144, 239, 0.35);
   animation: gradientShift 4s ease infinite;
   min-width: 320px;
   padding-left: 60px;
@@ -642,7 +640,7 @@
 
 .cot-demo-btn:hover {
   transform: translateY(-3px);
-  box-shadow: 0 15px 40px rgba(102, 126, 234, 0.6);
+  box-shadow: 0 18px 45px rgba(11, 144, 239, 0.45);
 }
 
 .cot-demo-btn:active {

--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
                             <!-- Live Example Section -->
                             <div class="cot-example-section wow fadeInUp" data-wow-delay="2.7s">
                                 <div class="example-header">
-                                    <h3>Automatic Iteration in Action</h3>
+                                    <!-- <h3>Automatic Iteration in Action</h3> -->
                                     <p>An example of how the two agents collaborate to refine responses</p>
                                 </div>
                                 


### PR DESCRIPTION
## Summary
- realign the featured project overlay and typography with the portfolio's blue branding for a cohesive look
- restyle thought bubbles, agent badges, and conversation cards with complementary navy and sky accents
- update supporting elements such as the CTA button and completion message to reuse the unified gradient palette

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f973afbe5c832489f320090861facf