### PR TITLE
Re-trigger Pages deploy after transient GitHub failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ This repo is served by GitHub Pages at **mbogard.com**.
 2. Copy the build into this repo's root (excluding source maps):
    `rsync -a --exclude='*.map' --exclude='.DS_Store' /path/to/drive-local/dist/ ./`
 3. Commit and push.
+
+If the Pages deploy job fails with "Deployment failed, try again later", it's a
+transient GitHub-side error — push any commit (like this one) to re-trigger it.


### PR DESCRIPTION
## Why

The latest `pages-build-deployment` run on `master` (commit `b9ad2fe`, "Better boards") failed with:

> Error: Deployment failed, try again later.

The build itself succeeded — the artifact was uploaded and the deployment was created, then GitHub's Pages infrastructure fell over. This is a transient GitHub-side error, not a code issue.

## What

A trivial README note (3 lines) so merging this produces a new push to `master`, which kicks off a fresh Pages deploy and gets the "Better boards" changes live.

Merge whenever — no review needed.